### PR TITLE
Fixes #17

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function createPluginOptions(api, projectOptions) {
     if (existsSync(oldConfigPath)) {
       Object.assign(options, JSON.parse(readFileSync(oldConfigPath).toString("utf-8")));
     }
-  } catch {
+  } catch (err) {
     if (existsSync(oldConfigPath)) {
       options = JSON.parse(readFileSync(oldConfigPath).toString("utf-8"));
     }


### PR DESCRIPTION
Running `npm run build` fails with the below error, this ought to stop that from happening (though the `err` variable will go unused).

Should fix #17 

```
node -v
v8.15.0

npm -v
6.4.1

vue --version
3.3.0
```

```
jarrod@zhd02:~/app/zhdict-ng$ npm run build

> zhdict-ng@3.0.1 build /home/jarrod/app/zhdict-ng
> vue-cli-service build

/home/jarrod/app/zhdict-ng/node_modules/vue-cli-plugin-prerender-spa/index.js:101
  } catch {
          ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at idToPlugin (/home/jarrod/app/zhdict-ng/node_modules/@vue/cli-service/lib/Service.js:136:14)
````

<!-- First open an issue in order to engage the author and the community - then work on your PR. -->

**What**:

**Why**:

**How**:

- [ ] I am working based off of `develop`
- [ ] I have rebased my PR off of `develop`
