### PR TITLE
Fixes #34 if there's no pluginOptions.prerenderSpa in vue.config.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ function entry(api, projectOptions) {
 function chain(api, projectOptions) {
   return config => {
     const options = createPluginOptions(api, projectOptions);
+    if(!options || options.disable) return // If there aren't any options or disabled, don't run
     if (options.onlyProduction && process.env.NODE_ENV !== "production") {
       return;
     }
@@ -95,7 +96,7 @@ function createRendererConfig(api, projectOptions) {
 }
 
 function createPluginOptions(api, projectOptions) {
-  let options;
+  let options = {}; // Fixes Object.assign error if there's no 'pluginOptions.prerenderSpa' in vue.config.js
   let oldConfigPath = api.resolve(".prerender-spa.json");
   try {
     options = pickle(projectOptions, CONFIG_OBJ_PATH);
@@ -107,6 +108,7 @@ function createPluginOptions(api, projectOptions) {
       options = JSON.parse(readFileSync(oldConfigPath).toString("utf-8"));
     }
   }
+  if(Object.entries(options).length === 0) return undefined // No options at all, therefore don't return any options.
   // return options; // TODO: Fix #16 permanently
   return Object.assign(options, { onlyProduction: true }); // Force disable on development build, workaround for #16
 }


### PR DESCRIPTION
**What**:
Build fails if there's no pluginOptions.prerenderSpa in vue.config.js (closes #34)

**Why**:
The options variable doesn't get assigned in the function createPluginOptions (src/index.js) if there's no options to assign to it. This causes Object.assign to fail.

**How**:
This PR resolved the issue in multiple ways:
It initially assigns options the value `{}` (empty object) in case it won't be reassigned any value.

It also checks if there weren't any options enabled at all, and in that case, returns `undefined`. This is so that it can be checked if there ever was any options given in vue.config.js. In my opinion, I think that should be interpreted as the developer not wanting to use the plugin, and therefore not run.

It finally implements a way to disable the plugin by having `disable: true` in pluginOptions.prerenderSpa, e.g.
```
pluginOptions: {
  prerenderSpa: {
    disabled: true
  }
},
```

That way you can have options, but still disable the plugin if necessary (for example when testing).

- [x] I am working based off of `develop`
- [x] I have rebased my PR off of `develop`
