### PR TITLE
Add polyfill for IE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   ],
   "private": false,
   "dependencies": {
-    "prerender-spa-plugin": "^3.2.1"
+    "prerender-spa-plugin": "^3.2.1",
+    "recast": "^0.18.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/generator.js
+++ b/src/generator.js
@@ -46,7 +46,12 @@ function astMutAddEventPolyfill(source) {
   const polyfill = parse(`function createNewEvent(eventName) {
     var event;
     if (typeof(Event) === 'function') {
-        event = new Event(eventName);
+        try {
+          event = new Event(eventName);
+        } catch (e) {
+          event = document.createEvent('Event');
+          event.initEvent(eventName, true, true);
+        }
     } else {
         event = document.createEvent('Event');
         event.initEvent(eventName, true, true);

--- a/src/generator.js
+++ b/src/generator.js
@@ -124,5 +124,9 @@ function astInsertEventInBlock(astBlock) {
 }
 
 function astDispatchRenderEvent() {
-  return b.expressionStatement(b.callExpression(b.identifier("createNewEvent"), [b.literal("x-app-rendered")]));
+  return b.expressionStatement(
+    b.callExpression(b.memberExpression(b.identifier("document"), b.identifier("dispatchEvent")), [
+      b.callExpression(b.identifier("createNewEvent"), [b.literal("x-app-rendered")])
+    ])
+  );
 }

--- a/src/generator.js
+++ b/src/generator.js
@@ -29,14 +29,14 @@ function generate(api, options) {
       fs.writeFileSync(mainPath, print(orig).code, { encoding: "utf-8" });
     }
   });
-
+  const { registry, ...prerenderSpa } = options;
   api.extendPackage({
     devDependencies: {
       "prerender-spa-plugin": "^3.2.1"
     },
     vue: {
       pluginOptions: {
-        prerenderSpa: options
+        prerenderSpa
       }
     }
   });

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,3 +1,6 @@
+const { parse, print, types, visit } = require("recast");
+const b = types.builders;
+
 export default generate;
 module.exports = generate;
 
@@ -8,17 +11,22 @@ function generate(api, options) {
     if (options.useRenderEvent) {
       const ext = api.hasPlugin("typescript") ? "ts" : "js";
       const mainPath = api.resolve(`./src/main.${ext}`);
+      const orig = parse(fs.readFileSync(mainPath, { encoding: "utf-8" }));
+      astMutAddEventPolyfill(orig);
+      visit(orig, {
+        visitNewExpression(path) {
+          const stmt = path.node;
+          if (stmt.callee.type === "Identifier" && stmt.callee.name === "Vue") {
+            const idx = stmt.arguments.findIndex(a => a.type === "ObjectExpression");
+            if (idx !== -1) {
+              stmt.arguments.splice(idx, 1, astInsertMountedHook(stmt.arguments[idx]));
+            }
+          }
 
-      const mainFileLines = fs
-        .readFileSync(mainPath, { encoding: "utf-8" })
-        .split(/\r?\n/g)
-        .reverse();
-      const vueRenderIndex = mainFileLines.findIndex(line => line.match(/render\:/));
-      if (!mainFileLines[vueRenderIndex].endsWith(",")) mainFileLines[vueRenderIndex] += ",";
-      mainFileLines[vueRenderIndex] += '\n  mounted: () => document.dispatchEvent(new Event("x-app-rendered")),';
-      fs.writeFileSync(mainPath, mainFileLines.reverse().join("\n"), {
-        encoding: "utf-8"
+          this.traverse(path);
+        }
       });
+      fs.writeFileSync(mainPath, print(orig).code, { encoding: "utf-8" });
     }
   });
 
@@ -32,4 +40,85 @@ function generate(api, options) {
       }
     }
   });
-};
+}
+
+function astMutAddEventPolyfill(source) {
+  const polyfill = parse(`function createNewEvent(eventName) {
+    var event;
+    if (typeof(Event) === 'function') {
+        event = new Event(eventName);
+    } else {
+        event = document.createEvent('Event');
+        event.initEvent(eventName, true, true);
+    }
+    return event;
+}
+`);
+  const idx = source.program.body.findIndex(n => n.type === "ExpressionStatement");
+  if (idx !== -1) {
+    source.program.body.splice(idx, 0, ...polyfill.program.body);
+  } else {
+    source.program.body.append(...polyfill.program.body);
+  }
+}
+
+/**
+ *
+ * @param {types.namedTypes.ObjectExpression} obj
+ */
+function astInsertMountedHook(obj) {
+  const appProperties = Object.assign({}, obj);
+  const mountedHookIdx = appProperties.properties.findIndex(p => p.key.name === "mounted");
+  if (mountedHookIdx !== -1) {
+    const prop = appProperties.properties[mountedHookIdx];
+    switch (prop.value.type) {
+      case "FunctionExpression":
+        prop.value.body = astInsertEventInBlock(prop.value.body);
+        break;
+      case "ArrowFunctionExpression":
+        if (prop.value.body.type === "BlockStatement") {
+          prop.value.body = astInsertEventInBlock(prop.value.body);
+        } else {
+          prop.value = b.blockStatement([
+            b.variableDeclaration("const", [b.variableDeclarator(b.identifier("result"), prop.value.body)]),
+            astDispatchRenderEvent(),
+            b.returnStatement(b.identifier("result"))
+          ]);
+        }
+        break;
+      default:
+        // Invalid type for Vue, overwriting
+        console.error("WARNING: Invalid type for mounted hook of Vue root component, overwriting...");
+        prop.value = b.blockStatement([astDispatchRenderEvent()]);
+    }
+    appProperties.properties.slice(mountedHookIdx, 1, prop);
+  } else {
+    appProperties.properties.push(
+      b.property(
+        "init",
+        b.identifier("mounted"),
+        b.arrowFunctionExpression([], b.blockStatement([astDispatchRenderEvent()]))
+      )
+    );
+  }
+
+  return appProperties;
+}
+
+function astInsertEventInBlock(astBlock) {
+  const retIdx = astBlock.body.findIndex(n => n.type === "ReturnStatement");
+  if (retIdx === -1) {
+    return b.blockStatement([...astBlock.body, astDispatchRenderEvent()]);
+  } else {
+    let astReturnStmt = astBlock.body[retIdx].argument;
+    const astRetVal = b.variableDeclaration("const", [b.variableDeclarator(b.identifier("result"), astReturnStmt)]);
+    astReturnStmt = b.returnStatement(b.identifier("result"));
+    let retval = astBlock.body.slice();
+    retval.splice(retIdx, 1, astRetVal, astDispatchRenderEvent(), astReturnStmt);
+    return b.blockStatement(retval);
+  }
+}
+
+function astDispatchRenderEvent() {
+  return b.expressionStatement(b.callExpression(b.identifier("createNewEvent"), [b.literal("x-app-rendered")]));
+}

--- a/src/generator.js
+++ b/src/generator.js
@@ -106,6 +106,10 @@ function astInsertMountedHook(obj) {
 }
 
 function astInsertEventInBlock(astBlock) {
+  // Check whether similar event-dispatching already exists (make function idempotent)
+  if (astBlock.body.filter(n => types.astNodesAreEquivalent(n, astDispatchRenderEvent())).length > 0) {
+    return Object.assign({}, astBlock);
+  }
   const retIdx = astBlock.body.findIndex(n => n.type === "ReturnStatement");
   if (retIdx === -1) {
     return b.blockStatement([...astBlock.body, astDispatchRenderEvent()]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,6 +695,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types@0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
+  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -1048,6 +1053,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+esprima@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -1947,7 +1957,7 @@ prerender-spa-plugin@^3.2.1:
     "@prerenderer/renderer-puppeteer" "^0.1.4"
     html-minifier "^3.5.16"
 
-private@^0.1.6:
+private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -2035,6 +2045,16 @@ readdirp@^2.0.0:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+recast@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.2.tgz#ada263677edc70c45408caf20e6ae990958fdea8"
+  integrity sha512-MbuHc1lzIDIn7bpxaqIAGwwtyaokkzPqINf1Vm/LA0BSyVrTgXNVTTT7RzWC9kP+vqrUoYVpd6wHhI8x75ej8w==
+  dependencies:
+    ast-types "0.13.2"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
<!-- First open an issue in order to engage the author and the community - then work on your PR. -->

**What**: This PR adds a polyfill to add support for IE (urgh)

**Why**: It seems that IE is still, for some reason, used by people (closes #40)

**How**: I had to rewrite the whole generator to transform AST in order to support the changes that needed to be made to the Vue app entrypoint file

---

This PR also closes #29 as the "registry" key from the generator options isn't written to config anymore.

- [x] I am working based off of `develop`
- [x] I have rebased my PR off of `develop`
